### PR TITLE
Better scrolling, portable configuration mode

### DIFF
--- a/terminalpp/config.cpp
+++ b/terminalpp/config.cpp
@@ -5,7 +5,7 @@
 #include "application.h"
 #include "config.h"
 
-namespace tpp { 
+namespace tpp {
 
     Config & Config::Setup(int argc, char * argv[]) {
         MARK_AS_UNUSED(argc);
@@ -13,7 +13,10 @@ namespace tpp {
         Config & config = Instance();
         bool saveSettings = false;
         bool backupSettings = false;
-        std::string filename = GetSettingsFile();
+        std::string filename = []{
+            if (access ("settings.json", R_OK) == 0) return std::string("settings.json");
+            else return GetSettingsFile();
+        }();
         {
             std::ifstream f{filename};
             if (f.good()) {
@@ -38,7 +41,7 @@ namespace tpp {
 					saveSettings = true;
                     backupSettings = true;
 				}
-				// if there were any errors with the settings, create backup of the old settings as new settings will be stored. 
+				// if there were any errors with the settings, create backup of the old settings as new settings will be stored.
 				if (backupSettings) {
 					std::string backup{MakeUnique(filename)};
 					Application::Instance()->alert(STR("New settings file will be saved, backup stored in " << backup));
@@ -56,7 +59,7 @@ namespace tpp {
                 config.patchSessions();
             }
         }
-        // if the settings should be saved, save them now 
+        // if the settings should be saved, save them now
         if (saveSettings) {
             CreatePath(GetSettingsFolder());
             std::ofstream f(filename);
@@ -92,14 +95,14 @@ namespace tpp {
             if (vCurrent < vMin)
         		Application::Instance()->alert(STR("Settings version differs from current terminal version (" << PROJECT_VERSION << "). The configuration will be updated to the new version."));
         } catch (...) {
-            Application::Instance()->alert("Invalid settings version detected. The configuration will be updated to the current version");        
-        }        
+            Application::Instance()->alert("Invalid settings version detected. The configuration will be updated to the current version");
+        }
         userConfig.erase("version");
 	}
 
-    /** First determine if session list should be checked at all times (application.detectSessionsAtStartup), or sessions not present in the JSON (in which case we add them as an empty list). 
-     
-        If above true, then update the list with autodetected sessions. 
+    /** First determine if session list should be checked at all times (application.detectSessionsAtStartup), or sessions not present in the JSON (in which case we add them as an empty list).
+
+        If above true, then update the list with autodetected sessions.
      */
     bool Config::patchSessions() {
 
@@ -136,7 +139,7 @@ namespace tpp {
         }
         return updated;
     }
-    
+
     bool Config::addSession(JSON const & session) {
         for (auto existing : sessions)
             if (existing.name() == session["name"].toString())
@@ -257,7 +260,7 @@ namespace tpp {
                 if (WSLIsBypassPresent(distribution)) {
                     pty = "bypass";
                 } else {
-                    if (Application::Instance()->query("ConPTY Bypass Installation", STR("Do you want to install the ConPTY bypass, which allows for faster I/O and has full support for ANSI escape sequences into WSL distribution " << distribution))) 
+                    if (Application::Instance()->query("ConPTY Bypass Installation", STR("Do you want to install the ConPTY bypass, which allows for faster I/O and has full support for ANSI escape sequences into WSL distribution " << distribution)))
                         if (WSLInstallBypass(distribution)) {
                             pty = "bypass";
                         } else {
@@ -336,7 +339,7 @@ namespace tpp {
     }
 
     // C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell.exe -noe -c "&{Import-Module """C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"""; Enter-VsDevShell f77c1a05}"
-    /* The issue is that the last argument (f77c1a05) might be computer dependent and so it's not trivial to detect & reproduce here. Also the escaping for the import module path is off. 
+    /* The issue is that the last argument (f77c1a05) might be computer dependent and so it's not trivial to detect & reproduce here. Also the escaping for the import module path is off.
      */
     /*
     void Config::win32AddVSDevPs(std::string_view vsver, std::string_view edition, bool & updated) {

--- a/terminalpp/config.h
+++ b/terminalpp/config.h
@@ -13,7 +13,7 @@
 #include "ui/special_objects/hyperlink.h"
 
 /** \page tppconfig Configuration
- 
+
     \brief Describes the confifuration of the terminal application.
 
 	What I want:
@@ -23,11 +23,11 @@
 	- one place to define the options and their defaults
  */
 
-/** The oldest compatible settings version. 
- 
+/** The oldest compatible settings version.
+
     If upgrading terminal from version above or equal to the one set here, the upgrade is silent because the configuration files should be almost identical (i.e. new version should have only additions).
 
-    In other cases a version upgrade dialog is displayed and a copy of the settings should be made before terminal updates to new version. 
+    In other cases a version upgrade dialog is displayed and a copy of the settings should be made before terminal updates to new version.
     */
 constexpr char const * const MIN_COMPATIBLE_VERSION = "0.8.0";
 //#define MIN_COMPATIBLE_VERSION "0.8.0"
@@ -37,8 +37,8 @@ constexpr char const * const BYPASS_PATH = "~/.local/bin/tpp-bypass";
 
 constexpr char const * const DEFAULT_WINDOW_TITLE = "t++";
 
-/** Determines the default blink speed of the cursor or blinking text. 
- */ 
+/** Determines the default blink speed of the cursor or blinking text.
+ */
 constexpr size_t DEFAULT_BLINK_SPEED = 500;
 
 /** Keyboard shortcuts for various actions.
@@ -52,13 +52,20 @@ constexpr size_t DEFAULT_BLINK_SPEED = 500;
 #define SHORTCUT_ZOOM_IN_ALT (Key::Equals + Key::Ctrl + Key::Shift)
 #define SHORTCUT_ZOOM_OUT_ALT (Key::Minus + Key::Ctrl + Key::Shift)
 
-#define SHORTCUT_PASTE (Key::V + Key::Ctrl + Key::Shift)
-#define SHORTCUT_COPY (Key::C + Key::Ctrl)
+#define SHORTCUT_PASTE (Key::V + Key::Ctrl)
+#define SHORTCUT_PASTE_ALT (Key::V + Key::Ctrl + Key::Shift)
+#define SHORTCUT_COPY (Key::C + Key::Ctrl + Key::Shift)
 
+#define SHORTCUT_SCROLL_UP (Key::Up + Key::Ctrl + Key::Shift)
+#define SHORTCUT_SCROLL_DOWN (Key::Down + Key::Ctrl + Key::Shift)
+#define SHORTCUT_SCROLL_PAGE_UP (Key::PageUp + Key::Ctrl + Key::Shift)
+#define SHORTCUT_SCROLL_PAGE_DOWN (Key::PageDown + Key::Ctrl + Key::Shift)
+#define SHORTCUT_SCROLL_TOP (Key::Home + Key::Ctrl + Key::Shift)
+#define SHORTCUT_SCROLL_BOTTOM (Key::End + Key::Ctrl + Key::Shift)
 
 namespace config {
 
-    /** Typedef for font attributes specification only. 
+    /** Typedef for font attributes specification only.
      */
     typedef ui::Font FontAttributes;
 
@@ -68,8 +75,8 @@ namespace config {
         Multiline
     };
 
-    /** Determines whether the terminal applications can set local clipboard. 
-     
+    /** Determines whether the terminal applications can set local clipboard.
+
         If allowed, all requests to set clipboard will be processed immediately. If denied, all will be silently ignored and when set to ask, each request will require confirmation.
      */
     enum class AllowClipboardUpdate {
@@ -118,7 +125,7 @@ inline Command JSONConfig::FromJSON(JSON const & json) {
         THROW(JSONError()) << "Element must be an array";
     std::vector<std::string> cmd;
     for (auto i : json) {
-        if (i.kind() != JSON::Kind::String) 
+        if (i.kind() != JSON::Kind::String)
             THROW(JSONError()) << "Element items must be strings, but " << i.kind() << " found";
         cmd.push_back(i.toString());
     }
@@ -139,7 +146,7 @@ inline ui::AnsiTerminal::Palette JSONConfig::FromJSON(JSON const & json) {
     ui::AnsiTerminal::Palette result{ui::AnsiTerminal::Palette::XTerm256()};
     size_t i = 0;
     for (auto c : json) {
-        if (c.kind() != JSON::Kind::String) 
+        if (c.kind() != JSON::Kind::String)
             THROW(JSONError()) << "Element items must be HTML colors, but " << c.kind() << " found";
         // empty colors are skipped in the color configuration, leaving their default values
         if (! c.toString().empty())
@@ -165,17 +172,17 @@ inline std::vector<std::reference_wrapper<Log>> JSONConfig::FromJSON(JSON const 
         if (item.kind() != JSON::Kind::String)
             THROW(JSONError()) << "Strings expected in the array, but  " << item << " found";
         std::string const & logName = item.toString();
-        if (logName == "FATAL_ERROR") 
+        if (logName == "FATAL_ERROR")
             result.push_back(Telemetry::FatalErrorLog());
-        else if (logName == "EXCEPTION") 
+        else if (logName == "EXCEPTION")
             result.push_back(Log::Exception());
-        else if (logName == "TELEMETRY") 
+        else if (logName == "TELEMETRY")
             result.push_back(Telemetry::TelemetryLog());
-        else if (logName == "SEQ_ERROR") 
+        else if (logName == "SEQ_ERROR")
             result.push_back(ui::AnsiTerminal::SEQ_ERROR);
-        else if (logName == "SEQ_UNKNOWN") 
+        else if (logName == "SEQ_UNKNOWN")
             result.push_back(ui::AnsiTerminal::SEQ_UNKNOWN);
-        else if (logName == "SEQ_WONT_SUPPORT") 
+        else if (logName == "SEQ_WONT_SUPPORT")
             result.push_back(ui::AnsiTerminal::SEQ_WONT_SUPPORT);
         else
             THROW(JSONError()) << "Invalid log name " << logName;
@@ -187,13 +194,13 @@ template<>
 inline config::ConfirmPaste JSONConfig::FromJSON(JSON const & json) {
     if (json.kind() != JSON::Kind::String)
         THROW(JSONError()) << "Element must be an array";
-    if (json.toString() == "never") 
+    if (json.toString() == "never")
         return config::ConfirmPaste::Never;
     else if (json.toString() == "always")
         return config::ConfirmPaste::Always;
     else if (json.toString() == "multiline")
         return config::ConfirmPaste::Multiline;
-    else 
+    else
         THROW(JSONError()) << "Only values 'never', 'always' or 'multiline' are permitted";
 }
 
@@ -201,17 +208,17 @@ template<>
 inline config::AllowClipboardUpdate JSONConfig::FromJSON(JSON const & json) {
     if (json.kind() != JSON::Kind::String)
         THROW(JSONError()) << "Element must be an array";
-    if (json.toString() == "allow") 
+    if (json.toString() == "allow")
         return config::AllowClipboardUpdate::Allow;
     else if (json.toString() == "deny")
         return config::AllowClipboardUpdate::Deny;
     else if (json.toString() == "ask")
         return config::AllowClipboardUpdate::Ask;
-    else 
+    else
         THROW(JSONError()) << "Only values 'allow', 'deny' or 'ask' are permitted";
 }
 
-namespace tpp {	
+namespace tpp {
 
     class Config : public JSONConfig::CmdArgsRoot {
     public:
@@ -268,8 +275,8 @@ namespace tpp {
             renderer,
             "Renderer settings",
 		    CONFIG_PROPERTY(
-				fps, 
-				"Maximum FPS", 
+				fps,
+				"Maximum FPS",
 				JSON{60},
 			    unsigned
 			);
@@ -438,7 +445,7 @@ namespace tpp {
                 displayBold,
                 "If true bold font will be used when appropriate.",
                 JSON{true},
-                bool                
+                bool
             );
             CONFIG_PROPERTY(
                 allowOSCHyperlinks,
@@ -482,7 +489,7 @@ namespace tpp {
 				palette,
 				"Definition of the palette used for the session.",
 				CONFIG_PROPERTY(
-					colors, 
+					colors,
 					"Overrides the predefined palette. Up to 256 colors can be specified in HTML format. These colors will override the default xterm palette used.",
 					JSON::Array(),
 				    ui::AnsiTerminal::Palette
@@ -499,7 +506,7 @@ namespace tpp {
 					JSON{"#000000"},
 				    ui::Color
 				);
-				/** Provides a value getter on the entire palette configuration group which returns the palette with the default colors set accordingly. 
+				/** Provides a value getter on the entire palette configuration group which returns the palette with the default colors set accordingly.
 				 */
 				ui::AnsiTerminal::Palette * operator () () const {
 					auto result = new ui::AnsiTerminal::Palette{colors()};
@@ -554,10 +561,10 @@ namespace tpp {
             JSON{"default"},
             std::string
         );
-        /* The list of sessings and their override settings. 
+        /* The list of sessings and their override settings.
          */
         CONFIG_ARRAY(
-            sessions, 
+            sessions,
             "List of known sessions",
             JSON::Array(),
             CONFIG_PROPERTY(
@@ -579,7 +586,7 @@ namespace tpp {
 			    std::string
 			);
 			CONFIG_PROPERTY(
-				command, 
+				command,
 				"The command to be executed in the session",
 				JSON::Array(),
 			    Command
@@ -594,7 +601,7 @@ namespace tpp {
 				palette,
 				"Definition of the palette used for the session.",
 				CONFIG_PROPERTY(
-					colors, 
+					colors,
 					"Overrides the predefined palette. Up to 256 colors can be specified in HTML format. These colors will override the default xterm palette used.",
 					JSON::Array(),
 				    ui::AnsiTerminal::Palette
@@ -611,12 +618,12 @@ namespace tpp {
 					JSON{"#000000"},
 				    ui::Color
 				);
-				/** Provides a value getter on the entire palette configuration group which returns the palette with the default colors set accordingly. 
+				/** Provides a value getter on the entire palette configuration group which returns the palette with the default colors set accordingly.
 				 */
 				ui::AnsiTerminal::Palette operator () () const {
                     ui::AnsiTerminal::Palette result{colors()};
 					result.setDefaultForeground(defaultForeground());
-					result.setDefaultBackground(defaultBackground());                    
+					result.setDefaultBackground(defaultBackground());
 					return result;
 				}
 			);
@@ -660,11 +667,11 @@ namespace tpp {
 			);
         );
 
-        /** Initializes the configuration. 
-         
-            Reads the configuration if one exists. Then fills in missing values and updates the stored settings if necessary. If there are any errors with reading the settings, creates a backup of the old settings before creating new ones. 
+        /** Initializes the configuration.
 
-            Also checks the stored version and current version and informs the user if there is a possibility of any breaking change. 
+            Reads the configuration if one exists. Then fills in missing values and updates the stored settings if necessary. If there are any errors with reading the settings, creates a backup of the old settings before creating new ones.
+
+            Also checks the stored version and current version and informs the user if there is a possibility of any breaking change.
          */
         static Config & Setup(int argc, char* argv[]);
 
@@ -673,16 +680,16 @@ namespace tpp {
             return instance;
         }
 
-		/** Returns the directory in which the configuration files should be located. 
+		/** Returns the directory in which the configuration files should be located.
 		 */
 	    static std::string GetSettingsFolder();
 
-		/** Returns the actual settings file, i.e. the `settings.json` file in the settings directory. 
+		/** Returns the actual settings file, i.e. the `settings.json` file in the settings directory.
 		 */
 	    static std::string GetSettingsFile();
 
-        /** Returns the version of the terminal++ binary. 
-		 
+        /** Returns the version of the terminal++ binary.
+
 		    This version is specified in the CMakeLists.txt and is watermarked to each binary.
 		 */
 	    static JSON TerminalVersion();
@@ -705,19 +712,19 @@ namespace tpp {
             if (font.doubleWidth()) {
                 if (font.bold() && renderer.font.doubleWidthBoldFamily.updated())
                     return renderer.font.doubleWidthBoldFamily();
-                else   
+                else
                     return renderer.font.doubleWidthFamily();
             } else {
                 if (font.bold() && renderer.font.boldFamily.updated())
                     return renderer.font.boldFamily();
-                else   
+                else
                     return renderer.font.family();
             }
         }
 
     protected:
-        /** Parses the command line arguments. 
-            
+        /** Parses the command line arguments.
+
          */
         void parseCommandLine(int argc, char * argv[]) {
             addArgument(renderer.fps, { "--fps"});
@@ -753,19 +760,19 @@ namespace tpp {
                 // copy the working directory
                 if (cmdSession.workingDirectory.updated())
                     session.workingDirectory.set(cmdSession.workingDirectory.toJSON());
-                // set the session name and set it as default session 
+                // set the session name and set it as default session
                 JSON name{"command-line-override"};
                 defaultSession.set(name);
                 session.name.set(name);
-            } 
+            }
             sessions.erase(cmdSession);
         }
 
     private:
 
-        /** Verifies the configuration version stored in the settings. 
-         
-            If the version is different than current version of the program, clears the version info so that it gets regenerated. If the old version is lower than the MIN_COMPATIBLE_VERSION, displays a warning that settings will be updated. 
+        /** Verifies the configuration version stored in the settings.
+
+            If the version is different than current version of the program, clears the version info so that it gets regenerated. If the old version is lower than the MIN_COMPATIBLE_VERSION, displays a warning that settings will be updated.
          */
         static void VerifyConfigurationVersion(JSON & userConfig);
 
@@ -776,15 +783,15 @@ namespace tpp {
         bool addSession(JSON const & session);
 
 		/** \name Default value providers
-		 
-		    These static methods calculate default values for the complex configuration properties. The idea is that these will be executed once the terminal is installed, they will analyze the system and calculate proper values to be stored in the configuration file. 
+
+		    These static methods calculate default values for the complex configuration properties. The idea is that these will be executed once the terminal is installed, they will analyze the system and calculate proper values to be stored in the configuration file.
 		 */
 		//@{
 
-		
+
 		static JSON DefaultTelemetryDir();
 
-		static JSON DefaultRemoteFilesDir();		
+		static JSON DefaultRemoteFilesDir();
 
 		static JSON DefaultFontFamily();
 
@@ -799,37 +806,37 @@ namespace tpp {
 
         static bool WSLIsBypassPresent(std::string const & distro);
 
-        /** Installs the bypass from the latest release. 
-         
-            Since 0.8.3 a single executable is used for all WSL distributions. 
+        /** Installs the bypass from the latest release.
+
+            Since 0.8.3 a single executable is used for all WSL distributions.
          */
         static bool WSLInstallBypass(std::string const & distro);
 
-        /** Adds the cmd.exe session to the list of sessions and sets it as default. 
-         
-            `cmd.exe` is expected to be installed on every Windows computer so is added without check. 
+        /** Adds the cmd.exe session to the list of sessions and sets it as default.
+
+            `cmd.exe` is expected to be installed on every Windows computer so is added without check.
          */
         void win32AddCmdExe(std::string & defaultSessionName, bool & updated);
 
-        /** Adds the powershell session to the list of sessions and sets it as default. 
-         
-            `powershell` is expected to be installed on every Windows computer so is added without check. 
+        /** Adds the powershell session to the list of sessions and sets it as default.
+
+            `powershell` is expected to be installed on every Windows computer so is added without check.
          */
         void win32AddPowershell(std::string & defaultSessionName, bool & updated);
 
-        /** Adds sessions for WSL distributions and sets the default WSL distro as default session. 
-         
-            The presence of WSL and its distributions and their names is checked as it's an optional feature. 
+        /** Adds sessions for WSL distributions and sets the default WSL distro as default session.
+
+            The presence of WSL and its distributions and their names is checked as it's an optional feature.
          */
         void win32AddWSL(std::string & defaultSessionName, bool & updated);
 
         /** Adds sessions for msys2, if found.
-         
+
             Does not set msys2 as the default session. The msys2 session specifications are taken from  https://www.msys2.org/docs/terminals/.
          */
         void win32AddMsys2(std::string & defaultSessionName, bool & updated);
 
-        /** Adds sessions for visual studio development command prompt. 
+        /** Adds sessions for visual studio development command prompt.
 
             At the moment, only the dev cmd.exe is supported as setting up the powershell seems to require install dir argument which is machine specific and therefore has to be loaded from the shortcut, which is non-trivial.
          */

--- a/terminalpp/forms/terminal_window.h
+++ b/terminalpp/forms/terminal_window.h
@@ -17,7 +17,7 @@
 
 namespace tpp {
 
-    /** New Version Dialog. 
+    /** New Version Dialog.
      */
     class NewVersionDialog : public ui::Dialog::Cancel {
     public:
@@ -31,7 +31,7 @@ namespace tpp {
         Label * contents_;
     };
 
-    /** Paste confirmation dialog. 
+    /** Paste confirmation dialog.
      */
     class PasteDialog : public ui::Dialog::YesNoCancel {
     public:
@@ -58,9 +58,9 @@ namespace tpp {
 
     private:
         Label * contents_;
-    };     
+    };
 
-    /** Clipboard copy confirmation dialog. 
+    /** Clipboard copy confirmation dialog.
      */
     class CopyDialog : public ui::Dialog::YesNoCancel {
     public:
@@ -88,15 +88,15 @@ namespace tpp {
         Label * contents_;
     };
 
-    /** The terminal window. 
-     
-        
+    /** The terminal window.
+
+
      */
     class TerminalWindow : public ui::Window {
     public:
 
         explicit TerminalWindow(tpp::Window * window):
-            window_{window}, 
+            window_{window},
             main_{new Panel{}},
             pager_{new Pager{}} {
 
@@ -147,7 +147,7 @@ namespace tpp {
             std::string title;
             AnsiTerminal * terminal = nullptr;
             bool terminateOnKeyPress = false;
-            /** If true, the current session has an active notification. 
+            /** If true, the current session has an active notification.
              */
             bool notification = false;
             PasteDialog * pendingPaste = nullptr;
@@ -160,17 +160,17 @@ namespace tpp {
             ~SessionInfo() {
                 delete terminal;
             }
-        }; 
+        };
 
-        /** The window has been requested to close. 
-         
-            TODO check that there are no active sessions and perhaps ask if there are whether really to exit. 
+        /** The window has been requested to close.
+
+            TODO check that there are no active sessions and perhaps ask if there are whether really to exit.
          */
         void windowCloseRequest(tpp::Window::CloseEvent::Payload & e) {
             MARK_AS_UNUSED(e);
         }
 
-        /** Global hotkeys handling. 
+        /** Global hotkeys handling.
          */
         void windowKeyDown(tpp::Window::KeyEvent::Payload & e) {
             // a keydown also clears any active notification in the current session, and if this is the last active notification, also the notification icon
@@ -219,7 +219,7 @@ namespace tpp {
             if (sessions_.empty())
                 window_->requestClose();
             // otherwise focus the active session instead
-            // TODO do we want this always, or should we actually check if the remove session was focused first? 
+            // TODO do we want this always, or should we actually check if the remove session was focused first?
             else
                 window_->setKeyboardFocus(pager_->activePage());
         }
@@ -239,9 +239,9 @@ namespace tpp {
             Application::Instance()->setClipboard(*e);
         }
 
-        /** Changes the icon when terminal sends notification. 
-         
-            Changes the icon, marks the notification flag for the terminal's session and increments the window notifications counter. 
+        /** Changes the icon when terminal sends notification.
+
+            Changes the icon, marks the notification flag for the terminal's session and increments the window notifications counter.
          */
         void sessionNotification(ui::VoidEvent::Payload & e) {
             SessionInfo * si = sessionInfo(e.sender());
@@ -254,9 +254,9 @@ namespace tpp {
         }
 
         void keyDown(KeyEvent::Payload & e) override {
-            if (activeSession_->terminateOnKeyPress && ! e->isModifierKey()) 
+            if (activeSession_->terminateOnKeyPress && ! e->isModifierKey())
                 closeSession(activeSession_);
-            else 
+            else
                 Widget::keyDown(e);
         }
 
@@ -330,8 +330,20 @@ namespace tpp {
 
         void terminalKeyDown(KeyEvent::Payload & e) {
             SessionInfo * si = sessionInfo(e.sender());
-            if (*e == SHORTCUT_PASTE) {
+            if (*e == SHORTCUT_PASTE || *e == SHORTCUT_PASTE_ALT) {
                 si->terminal->requestClipboardPaste();
+            } else if (*e == SHORTCUT_SCROLL_UP) {
+                si->terminal->scrollBy(Point{0, -3});
+            } else if (*e == SHORTCUT_SCROLL_DOWN) {
+                si->terminal->scrollBy(Point{0, 3});
+            } else if (*e == SHORTCUT_SCROLL_PAGE_UP) {
+                si->terminal->scrollBy(Point{0, -si->terminal->height()});
+            } else if (*e == SHORTCUT_SCROLL_PAGE_DOWN) {
+                si->terminal->scrollBy(Point{0, si->terminal->height()});
+            } else if (*e == SHORTCUT_SCROLL_TOP) {
+                si->terminal->scrollBy(Point{0, INT_MIN});
+            } else if (*e == SHORTCUT_SCROLL_BOTTOM) {
+                si->terminal->scrollBy(Point{0, INT_MAX});
             } else {
                 return;
             }
@@ -391,7 +403,7 @@ namespace tpp {
         ui::Panel * main_;
         ui::Pager * pager_;
 
-        std::unordered_map<AnsiTerminal *, SessionInfo *> sessions_; 
+        std::unordered_map<AnsiTerminal *, SessionInfo *> sessions_;
 
         SessionInfo * activeSession_ = nullptr;
         unsigned activeNotifications_ = 0;

--- a/ui/widget.h
+++ b/ui/widget.h
@@ -23,12 +23,12 @@ namespace ui {
 
     class Widget;
 
-    /** Base class for all ui widgets. 
-     
-        
-     
-     
-     
+    /** Base class for all ui widgets.
+
+
+
+
+
      */
     class Widget {
         friend class Renderer;
@@ -38,7 +38,7 @@ namespace ui {
     public:
 
         Widget() = default;
-        
+
         virtual ~Widget() {
             for (Widget * child : children_)
                 delete child;
@@ -48,17 +48,17 @@ namespace ui {
 
     // ============================================================================================
     /** \name Event Scheduling
-     
-        The widget has a shorthand schedule() method which can be used to schedule a new event linked to the widget. 
 
-        Each widget also remembers the number of pending events, i.e. events that were scheduled, but not yet executed so that when the widget is detached, the events can be cancelled automatically. 
+        The widget has a shorthand schedule() method which can be used to schedule a new event linked to the widget.
+
+        Each widget also remembers the number of pending events, i.e. events that were scheduled, but not yet executed so that when the widget is detached, the events can be cancelled automatically.
      */
     //@{
-#ifndef NDEBUG 
-    public: 
-        /** Check to make sure that code is executed in main UI thread. 
-         
-            This is only enabled in debug builds. See the UI_THREAD_ONLY macro for more details. 
+#ifndef NDEBUG
+    public:
+        /** Check to make sure that code is executed in main UI thread.
+
+            This is only enabled in debug builds. See the UI_THREAD_ONLY macro for more details.
          */
         static std::thread::id UIThreadID() {
             static std::thread::id id{std::this_thread::get_id()};
@@ -67,16 +67,16 @@ namespace ui {
 #endif
 
     protected:
-        /** Schedules given event and links it to the current widget. 
-         
-            Does nothing if the widget is not attached to a renderer. 
+        /** Schedules given event and links it to the current widget.
+
+            Does nothing if the widget is not attached to a renderer.
          */
         void schedule(std::function<void()> event);
 
     private:
-        /** Number of pending events linked to the widget. 
-         
-            These are only accessed from the event queue and such are protected by the event queue access mutex. 
+        /** Number of pending events linked to the widget.
+
+            These are only accessed from the event queue and such are protected by the event queue access mutex.
          */
         size_t pendingEvents_{0};
 
@@ -85,61 +85,61 @@ namespace ui {
     // ============================================================================================
 
     /** \name Widget Tree
-     
-        The widgets are arranged in a tree. 
+
+        The widgets are arranged in a tree.
         */
     //@{
 
     public:
 
-        /** Returns the parent widget. 
-         
-            If the widget has no parent (is unattached, or is a root widget), returns false. 
+        /** Returns the parent widget.
+
+            If the widget has no parent (is unattached, or is a root widget), returns false.
         */
         Widget * parent() const {
             return parent_;
         }
 
-        /** Returns true if the widget dominates the current one in the widget tree. 
+        /** Returns true if the widget dominates the current one in the widget tree.
 
-            Widget is dominated by itself and by its own parents transitively. The root widget dominates *all* widgets. 
+            Widget is dominated by itself and by its own parents transitively. The root widget dominates *all* widgets.
             */
         bool isDominatedBy(Widget const * widget) const;
 
         /** Returns the closest common parent of itself and the widget in argument.
 
-            In graph theory, this is the Lowest Common Ancestor.  
+            In graph theory, this is the Lowest Common Ancestor.
             */
         Widget * commonParentWith(Widget const * other) const;
 
-        /** Given renderer (window) coordinates, returns those coordinates relative to the widget. 
-         
-            Can only be called for widgets which are attached to a renderer, translates the coordinates irrespectively of whether they belong to the target widget, or not. 
+        /** Given renderer (window) coordinates, returns those coordinates relative to the widget.
+
+            Can only be called for widgets which are attached to a renderer, translates the coordinates irrespectively of whether they belong to the target widget, or not.
             */
         Point toWidgetCoordinates(Point rendererCoords) const {
             ASSERT(renderer_ != nullptr);
             return rendererCoords - visibleArea_.offset();
         }
 
-        /** Given widget coordinates, returns those coordinates relative to the renderer's area (the window). 
-         
-            Can only be called for widgets which are attached to a renderer, translates the coordinates irrespectively of whether they are visible in the window, or not. 
+        /** Given widget coordinates, returns those coordinates relative to the renderer's area (the window).
+
+            Can only be called for widgets which are attached to a renderer, translates the coordinates irrespectively of whether they are visible in the window, or not.
             */
         Point toRendererCoordinates(Point widgetCoords) const {
             ASSERT(renderer_ != nullptr);
             return widgetCoords + visibleArea_.offset();
         }
 
-        /** Converts the widget coordinates to the coordinates of the widget contents. 
+        /** Converts the widget coordinates to the coordinates of the widget contents.
          */
         Point toContentsCoords(Point widgetCoords) {
             return widgetCoords + scrollOffset();
         }
 
-        /** Returns the widget that is directly under the given coordinates, or itself. 
+        /** Returns the widget that is directly under the given coordinates, or itself.
          */
         Widget * getMouseTarget(Point coords) {
-            for (Widget * child : children_) 
+            for (Widget * child : children_)
                 if (child->rect_.contains(coords))
                     return child->getMouseTarget(child->toWidgetCoordinates(toRendererCoordinates(coords)));
             return this;
@@ -152,11 +152,11 @@ namespace ui {
         Widget * prevWidget(std::function<bool(Widget*)> cond = nullptr) {
             return prevWidget(cond, this, true);
         }
-        
+
     protected:
 
         /** Adds given widget as a child so that it will be in front (painted after all its siblings).
-         * 
+         *
          */
         virtual void attach(Widget * child);
 
@@ -164,11 +164,11 @@ namespace ui {
          */
         virtual void attachBack(Widget * child);
 
-        /** Removes given widget from the child widgets. 
+        /** Removes given widget from the child widgets.
          */
         virtual void detach(Widget * child);
 
-        /** Returns true if the widget is a root widget, i.e. if it has no parent *and* is attached to a renderer. 
+        /** Returns true if the widget is a root widget, i.e. if it has no parent *and* is attached to a renderer.
          */
         bool isRootWidget() const {
             return (parent_ == nullptr) && (renderer_ != nullptr);
@@ -183,7 +183,7 @@ namespace ui {
         Widget * prevWidget(std::function<bool(Widget*)> cond, Widget * last, bool checkParent);
 
     private:
-        /** Mutex protecting the renderer pointer for the widget. 
+        /** Mutex protecting the renderer pointer for the widget.
          */
         std::mutex rendererGuard_;
 
@@ -201,9 +201,9 @@ namespace ui {
 
     public:
 
-        /** Returns whether the widget is visible or not. 
+        /** Returns whether the widget is visible or not.
 
-            Visible widget does not guarantee that the widget is actually visible for the end user, but merely means that the widget should be rendered when appropriate. Invisible widgets are never rendered and do not occupy any layout space.  
+            Visible widget does not guarantee that the widget is actually visible for the end user, but merely means that the widget should be rendered when appropriate. Invisible widgets are never rendered and do not occupy any layout space.
         */
         bool visible() const {
             return visible_;
@@ -217,7 +217,7 @@ namespace ui {
             }
         }
 
-        /** Returns the rectangle the widget occupies in its parent's contents area. 
+        /** Returns the rectangle the widget occupies in its parent's contents area.
          */
         Rect const & rect() const {
             return rect_;
@@ -259,57 +259,13 @@ namespace ui {
             }
         }
 
-        /** Moves the widget within its parent. 
+        /** Moves the widget within its parent.
          */
         virtual void move(Point const & topLeft);
 
-        /** Resizes the widget. 
+        /** Resizes the widget.
          */
         virtual void resize(Size const & size);
-
-    protected:
-
-        Layout * layout() const {
-            return layout_;
-        }
-
-        virtual void setLayout(Layout * value) {
-            if (layout_ != value) {
-                delete layout_;
-                layout_ = value;
-                relayout();
-            }
-        }
-
-        /** Returns the contents size. 
-         */
-        virtual Size contentsSize() const {
-            return rect_.size();
-        }
-
-        /** Returns the canvas used for the contents of the widget. 
-         
-            The canvas has the contentsSize() size and is scrolled according to the scrollOffset().
-         */
-        Canvas contentsCanvas(Canvas & from) const;
-
-        /** Returns the scroll offset of the contents. 
-         */
-        Point scrollOffset() const {
-            return scrollOffset_;
-        }
-
-        /** Updates the scroll offset of the widget. 
-         
-            When offset changes, the visible area must be recalculated and the widget repainted. 
-         */
-        virtual void setScrollOffset(Point const & value) {
-            if (value != scrollOffset_) {
-                scrollOffset_ = value;
-                updateVisibleArea();
-                repaint();
-            } 
-        }
 
         virtual void scrollBy(Point delta) {
             Point p = scrollOffset_ + delta;
@@ -325,9 +281,53 @@ namespace ui {
             setScrollOffset(p);
         }
 
-        /** Returns the hint about the contents size of the widget. 
-         
-            Depending on the widget's size hints returns the width and height the widget should have when autosized. 
+    protected:
+
+        Layout * layout() const {
+            return layout_;
+        }
+
+        virtual void setLayout(Layout * value) {
+            if (layout_ != value) {
+                delete layout_;
+                layout_ = value;
+                relayout();
+            }
+        }
+
+        /** Returns the contents size.
+         */
+        virtual Size contentsSize() const {
+            return rect_.size();
+        }
+
+        /** Returns the canvas used for the contents of the widget.
+
+            The canvas has the contentsSize() size and is scrolled according to the scrollOffset().
+         */
+        Canvas contentsCanvas(Canvas & from) const;
+
+        /** Returns the scroll offset of the contents.
+         */
+        Point scrollOffset() const {
+            return scrollOffset_;
+        }
+
+        /** Updates the scroll offset of the widget.
+
+            When offset changes, the visible area must be recalculated and the widget repainted.
+         */
+        virtual void setScrollOffset(Point const & value) {
+            if (value != scrollOffset_) {
+                scrollOffset_ = value;
+                updateVisibleArea();
+                repaint();
+            }
+        }
+
+        /** Returns the hint about the contents size of the widget.
+
+            Depending on the widget's size hints returns the width and height the widget should have when autosized.
 
             */
         virtual Size getAutosizeHint() {
@@ -351,41 +351,41 @@ namespace ui {
 
     private:
 
-        /** Bring canvas' visible area to own scope so that it can be used by children. 
+        /** Bring canvas' visible area to own scope so that it can be used by children.
          */
         using VisibleArea = Canvas::VisibleArea;
 
-        /** Obtains the contents visible area of the parent and then updates own and children's visible areas. 
+        /** Obtains the contents visible area of the parent and then updates own and children's visible areas.
          */
         void updateVisibleArea();
 
         void updateVisibleArea(VisibleArea const & parentArea, Renderer * renderer);
 
-        /** Renderer to which the widget is attached. 
+        /** Renderer to which the widget is attached.
          */
         Renderer * renderer_ = nullptr;
 
-        /** Visible area of the widget. 
+        /** Visible area of the widget.
          */
         Canvas::VisibleArea visibleArea_;
 
-        /** The rectangle of the widget within its parent's client area. 
+        /** The rectangle of the widget within its parent's client area.
          */
         Rect rect_;
 
-        /** The offset of the visible area in the contents rectangle. 
+        /** The offset of the visible area in the contents rectangle.
          */
         Point scrollOffset_;
 
-        /** Visibility of the widget. 
+        /** Visibility of the widget.
          */
         bool visible_ = true;
 
-        /** If true, the widget's relayout should be called after its parent relayout happens. Calling resize 
+        /** If true, the widget's relayout should be called after its parent relayout happens. Calling resize
          */
         //bool pendingRelayout_ = false;
 
-        /** True if the widget is currently being relayouted. 
+        /** True if the widget is currently being relayouted.
          */
         bool relayouting_ = false;
 
@@ -393,7 +393,7 @@ namespace ui {
          */
         bool overlaid_ = false;
 
-        /** The layout implementation for the widget. 
+        /** The layout implementation for the widget.
          */
         Layout * layout_ = new Layout::None{};
 
@@ -408,18 +408,18 @@ namespace ui {
 
      */
     //@{
-    
-    public: 
 
-        /** Repaints the widget. 
-         
-            Triggers the repaint of the widget. 
+    public:
+
+        /** Repaints the widget.
+
+            Triggers the repaint of the widget.
          */
         void repaint();
 
-        /** Schedules repaint. 
-         
-            This method can be called from a different thread. 
+        /** Schedules repaint.
+
+            This method can be called from a different thread.
          */
         void scheduleRepaint();
 
@@ -447,7 +447,7 @@ namespace ui {
 
     protected:
 
-        /** Simple RAII widget lock that when engaged prevents widget from repainting. 
+        /** Simple RAII widget lock that when engaged prevents widget from repainting.
          */
         class Lock {
         public:
@@ -463,56 +463,56 @@ namespace ui {
             }
         private:
             Widget * widget_;
-        }; 
+        };
 
-        /** Returns whether the widget is locked or not. 
-         
+        /** Returns whether the widget is locked or not.
+
             A locked widget will not repaint itself.
          */
         bool locked() const {
             return lock_ > 0;
         }
 
-        /** Called when repaint of the widget is requested. 
+        /** Called when repaint of the widget is requested.
 
-            Widget subclasses can override this method to delegate the repaint event to other widgets up the tree, such as in cases of transparent background widgets. 
+            Widget subclasses can override this method to delegate the repaint event to other widgets up the tree, such as in cases of transparent background widgets.
          */
         virtual void requestRepaint();
 
-        /** Paints given child. 
-         
-            This method is necessary because subclasses can't simply call paint() on the children because of C++ protection rules. 
+        /** Paints given child.
+
+            This method is necessary because subclasses can't simply call paint() on the children because of C++ protection rules.
             */
         void paintChild(Widget * child) {
             ASSERT(child->parent_ == this);
             child->paint();
         }
 
-        /** Immediately paints the widget. 
-         
-            This method is to be used when another widget is to be painted as part of its parent. It clears the pending repaint flag, unlocking future repaints of the widgets, creates the appropriate canvas and calls the paint(Canvas &) method to actually draw the widget. 
+        /** Immediately paints the widget.
 
-            To explicitly repaint the widget, the repaint() method should be called instead, which optimizes the number of repaints and tells the renderer to repaint the widget.                 
-            */        
+            This method is to be used when another widget is to be painted as part of its parent. It clears the pending repaint flag, unlocking future repaints of the widgets, creates the appropriate canvas and calls the paint(Canvas &) method to actually draw the widget.
+
+            To explicitly repaint the widget, the repaint() method should be called instead, which optimizes the number of repaints and tells the renderer to repaint the widget.
+            */
         void paint();
 
-        /** Returns the attached renderer. 
+        /** Returns the attached renderer.
          */
         Renderer * renderer() const {
             return renderer_;
         }
 
-        /** Determines whether a paint request in the given child's subtree is to be allowed or not. 
-         
-            Returns true if the request is to be allowed, false if the repaint is not necessary (such as the child will nevet be displayed, or parent has already scheduled its own repaint and so will repaint the child as well). 
-            
-            When blocking the child repaint, a parent has the option to perform its own repaint instead. 
+        /** Determines whether a paint request in the given child's subtree is to be allowed or not.
+
+            Returns true if the request is to be allowed, false if the repaint is not necessary (such as the child will nevet be displayed, or parent has already scheduled its own repaint and so will repaint the child as well).
+
+            When blocking the child repaint, a parent has the option to perform its own repaint instead.
             */
         virtual bool allowRepaintRequest(Widget * immediateChild);
 
-        /** Actual paint method. 
-         
-            Override this method in subclasses to actually paint the widget's contents using the provided canvas. The default implementation simply paints the widget's children. 
+        /** Actual paint method.
+
+            Override this method in subclasses to actually paint the widget's contents using the provided canvas. The default implementation simply paints the widget's children.
             */
         virtual void paint(Canvas & canvas) {
             MARK_AS_UNUSED(canvas);
@@ -526,7 +526,7 @@ namespace ui {
 
         friend class Lock;
 
-        /** Since widget's start detached, their paint is blocked by setting pending repaint to true. When attached, and repainted via its parent, the flag will be cleared. 
+        /** Since widget's start detached, their paint is blocked by setting pending repaint to true. When attached, and repainted via its parent, the flag will be cleared.
          */
         std::atomic<bool> pendingRepaint_ = true;
 
@@ -538,19 +538,19 @@ namespace ui {
     //@}
 
     // ============================================================================================
-    /** \name Generic Input 
+    /** \name Generic Input
      */
     public:
 
-        /** When a widget is enabled it responds to input. 
+        /** When a widget is enabled it responds to input.
          */
         bool enabled() const {
             return enabled_;
         }
 
         /** Enables or disables the widget
-         
-            Enabled widget is expected to respond to input events, while disabled widgets should ignore them. Disabled widget cannot be keyboard focused, but mouse & clipboard and selection events are still passed to the event and they should be ignored for other than visual purposes. 
+
+            Enabled widget is expected to respond to input events, while disabled widgets should ignore them. Disabled widget cannot be keyboard focused, but mouse & clipboard and selection events are still passed to the event and they should be ignored for other than visual purposes.
          */
         virtual void setEnabled(bool value = true);
 
@@ -575,7 +575,7 @@ namespace ui {
 
         bool mouseFocused() const;
 
-        /** Returns the mouse cursor that should be used for the widget. 
+        /** Returns the mouse cursor that should be used for the widget.
          */
         MouseCursor mouseCursor() const {
             return mouseCursor_;
@@ -584,14 +584,14 @@ namespace ui {
     protected:
 
         /** Sets the mouse cursor of the widget.
-         
-            If the widget has mouse focus, updates the cursor immediately with the renderer. 
+
+            If the widget has mouse focus, updates the cursor immediately with the renderer.
          */
         virtual void setMouseCursor(MouseCursor cursor);
 
-        /** Called when mouse enters the widget's visible area. 
-         
-            Sets the renderer's mouse cursor to the widget's mouse cursor and triggers the event. 
+        /** Called when mouse enters the widget's visible area.
+
+            Sets the renderer's mouse cursor to the widget's mouse cursor and triggers the event.
          */
         virtual void mouseIn(VoidEvent::Payload & e);
 
@@ -656,8 +656,8 @@ namespace ui {
         }
 
     private:
-        
-        /** Mouse cursor to be displayed over the widget. 
+
+        /** Mouse cursor to be displayed over the widget.
          */
         MouseCursor mouseCursor_ = MouseCursor::Default;
 
@@ -665,18 +665,18 @@ namespace ui {
 
     // ========================================================================================
     /** \name Keyboard Input
-     
+
      */
     //@{
     public:
 
-        /** Determines whether the widget supports obtaining keyboard focus, or not. 
+        /** Determines whether the widget supports obtaining keyboard focus, or not.
          */
         bool focusable() const {
             return focusable_;
         }
 
-        /** Returns true if the widget currently has keyboard focus. 
+        /** Returns true if the widget currently has keyboard focus.
          */
         bool focused() const;
 
@@ -688,26 +688,26 @@ namespace ui {
 
     protected:
 
-        /** Captures keyboard input for the current widget. 
+        /** Captures keyboard input for the current widget.
          */
         virtual void focus();
 
-        /** Releases the keyboard input capture. 
-         
-            Moves to the next focusable widget, or if there is no next widget simply releases the capture. 
+        /** Releases the keyboard input capture.
+
+            Moves to the next focusable widget, or if there is no next widget simply releases the capture.
          */
         virtual void defocus();
 
         virtual void setFocusable(bool value = true);
 
-        /** The widget has received keyboard focus. 
+        /** The widget has received keyboard focus.
          */
         virtual void focusIn(VoidEvent::Payload & e) {
             onFocusIn(e, this);
             repaint();
         }
 
-        /** The widget has lost keyboard focus. 
+        /** The widget has lost keyboard focus.
          */
         virtual void focusOut(VoidEvent::Payload & e) {
             onFocusOut(e, this);
@@ -735,7 +735,7 @@ namespace ui {
 
     private:
 
-        bool focusable_ = false; 
+        bool focusable_ = false;
 
     //@}
 
@@ -748,7 +748,7 @@ namespace ui {
 
     protected:
 
-        /** Triggered when previously received clipboard or selection contents are available. 
+        /** Triggered when previously received clipboard or selection contents are available.
          */
         virtual void paste(StringEvent::Payload & e) {
             onPaste(e, this);
@@ -769,10 +769,10 @@ namespace ui {
 
     public:
         /** Returns true if the widget is available to the user.
-          
-            I.e. if the widget is visible (so that it can be observed) and enabled (so that it can be interacted with).     
 
-            This is a static function that can be conveniently used as an argument to nextWidget() and prevWidget() methods. 
+            I.e. if the widget is visible (so that it can be observed) and enabled (so that it can be interacted with).
+
+            This is a static function that can be conveniently used as an argument to nextWidget() and prevWidget() methods.
          */
         static bool IsAvailable(Widget * w) {
             return w->visible() && w->enabled();


### PR DESCRIPTION
Currently scrolling is severely limited, to the point of making terminal unusable. This patch adds additional much needed scroll commands / shortcuts:

  * `Ctrl+Shift+Up`: scroll up.
  * `Ctrl+Shift+Down`: scroll down.
  * `Ctrl+Shift+PgUp`: scroll a whole screen up.
  * `Ctrl+Shift+PgDown`: scroll screen down.
  * `Ctrl+Shift+Home`: scroll to top.
  * `Ctrl+Shift+End`: scroll to bottom.

These mimic default Windows Terminal shortcuts.

When scrolling line-by-line, scroll by three lines at a time instead of one.

Portable configuration mode: don’t create `settings.json` in home folder if `settings.json` already exists in the same folder with `terminalpp` executable. Currently it simply checks in the current working directory (works most of the time) but ideally it should resolve the actual path to the executable and check there. Such check is more complicated to implement and I avoided it in this pull request for simplicity sake.

**Update**. Forgot to mention, there’s also additional shortcut for copy to clipboard: `Ctrl+Shift+C`, obviously.